### PR TITLE
Adapted to changes in Odin that made ODIN_ARCH an enum

### DIFF
--- a/bindings.odin
+++ b/bindings.odin
@@ -3,9 +3,9 @@ package tracy
 import "core:c"
 import "core:os"
 
-when os.OS == "darwin"  do foreign import tracy "tracy.dylib"
-when os.OS == "windows" do foreign import tracy "tracy.lib"
-when os.OS == "linux"   do foreign import tracy "tracy.o"
+when os.OS == .Darwin  do foreign import tracy "tracy.dylib"
+when os.OS == .Windows do foreign import tracy "tracy.lib"
+when os.OS == .Linux   do foreign import tracy "tracy.o"
 
 ___tracy_source_location_data :: struct {
 	name     : cstring,


### PR DESCRIPTION
ODIN_ARCH is now an enum so we need to change the os strings to their enum counterpart.